### PR TITLE
Allow for viewing and changing previous rounds

### DIFF
--- a/public/css/ohhell.css
+++ b/public/css/ohhell.css
@@ -129,6 +129,17 @@ input[type=number]{
   background-color: red;
 }
 
+/* Bids */
+.bids-round-number {
+  font-size: 50pt;
+  display: inline-block;
+}
+
+button.change-round {
+  display: inline-block;
+}
+
+
 .add-player-button, .add-player-button:hover {
   font-size: 16pt;
   margin: 5px;

--- a/src/scripts/mainMenu.jsx
+++ b/src/scripts/mainMenu.jsx
@@ -42,7 +42,7 @@ class LatestGames extends React.Component {
     this.state = {latestGames: []};
   };
 
-  componentWillMount() {
+  componentDidMount() {
     var latestGames = [];
     var dbRef = database.ref("games").orderByChild("dateCreated").limitToLast(this.props.numberOfGames);
     dbRef.once("value", function(data) {

--- a/src/scripts/ohHell.jsx
+++ b/src/scripts/ohHell.jsx
@@ -104,6 +104,7 @@ class OhHell extends React.Component {
         break;
       case PageEnum.ROUND_BIDS:
         partial = <RoundBids changePage={this.changePage.bind(this)}
+                    roundNumber={this.state.gameState.roundNumber}
                     gameState={this.state.gameState}
                     players={this.state.currentPlayers}
                     updateGameState={this.updateGameState.bind(this)}
@@ -111,6 +112,7 @@ class OhHell extends React.Component {
         break;
       case PageEnum.ROUND_TRICKS:
         partial = <RoundTricks changePage={this.changePage.bind(this)}
+                    roundNumber = {this.state.gameState.roundNumber}
                     gameState={this.state.gameState}
                     players={this.state.currentPlayers}
                     updateGameState={this.updateGameState.bind(this)}

--- a/src/scripts/roundBids.jsx
+++ b/src/scripts/roundBids.jsx
@@ -180,7 +180,7 @@ export default class RoundBids extends React.Component {
   render() {
     const roundNumber = this.state.roundNumber;
     const gameState = this.state.gameState;
-    const players = this.state.players;
+    const players = this.state.players.filter(x => x.joinedRound <= roundNumber);
     const numPlayers = players.length;
     const totalNumRounds = getNumberOfRounds(numPlayers);
     const dealerNumber = (roundNumber - 1) % numPlayers;
@@ -197,7 +197,7 @@ export default class RoundBids extends React.Component {
     const roundBalance = totalBids - roundNumber; 
 
     const canFinalize = currentBidder < 0 && roundBalance != 0;
-    const pendingBids = this.state.players.map((player) => (
+    const pendingBids = players.map((player) => (
       <div key={player.playerNumber}>
         <hr />
         <PendingBid

--- a/src/scripts/roundBids.jsx
+++ b/src/scripts/roundBids.jsx
@@ -9,7 +9,7 @@ export default class RoundBids extends React.Component {
   
   constructor(props) {
     super(props);
-    this.state= { roundNumber: this.props.roundNumber
+    this.state= { roundNumber: this.props.roundNumber,
                   players: this.props.players,
                   gameState: this.props.gameState,
                   newPlayerGUID: getGUID(),
@@ -182,8 +182,8 @@ export default class RoundBids extends React.Component {
         <hr />
         <PendingBid
           playerName={player.playerName}
-          currentScore={this.state.gameState[player.playerName].scores[this.roundNumber-2]}
-          currentBid={this.state.gameState[player.playerName].bids[this.roundNumber-1]}
+          currentScore={this.state.gameState[player.playerName].scores[roundNumber-2]}
+          currentBid={this.state.gameState[player.playerName].bids[roundNumber-1]}
           updateBid={this.updateBid.bind(this)}
           maxBid={10}
           isPerfect={player.isPerfect}

--- a/src/scripts/roundBids.jsx
+++ b/src/scripts/roundBids.jsx
@@ -21,6 +21,24 @@ export default class RoundBids extends React.Component {
     this.updateFirebase();
   }
 
+  decrementRound() {
+    this.changeRoundNumber(this.state.gameState.roundNumber - 1);
+  }
+
+  incrementRound() {
+    this.changeRoundNumber(this.state.gameState.roundNumber + 1);
+  }
+
+  changeRoundNumber(roundNumber) {
+    if (roundNumber > 0 && roundNumber <= getNumberOfRounds(this.state.players.length))
+    {
+      //not clear why both have to change...
+      this.setState({roundNumber: roundNumber});
+      this.state.gameState.roundNumber = roundNumber;
+      this.forceUpdate();
+    }
+  }
+
   goToRoundTricks() {
     this.updateFirebase();
     this.props.updateGameState(this.state.players, this.state.gameState);
@@ -90,7 +108,6 @@ export default class RoundBids extends React.Component {
   }
 
   updateFirebase() {
-    console.log(this.state.gameState.isDebug);
     if (!this.state.gameState.isDebug)
     {
       var updates = {};
@@ -158,12 +175,12 @@ export default class RoundBids extends React.Component {
     bid being updated, in that case.
   */
   render() {
-    const roundNumber = this.props.roundNumber;
-    const gameState = this.props.gameState;
-    const players = this.props.players;
+    const roundNumber = this.state.roundNumber;
+    const gameState = this.state.gameState;
+    const players = this.state.players;
     const numPlayers = players.length;
     const totalNumRounds = getNumberOfRounds(numPlayers);
-    const dealerNumber = (roundNumber -1) % numPlayers;
+    const dealerNumber = (roundNumber - 1) % numPlayers;
     let currentBidder = (dealerNumber + 1) % numPlayers;
     while(gameState[players[currentBidder].playerName].bids[roundNumber-1] !== "-") {
       currentBidder = (currentBidder + 1) % numPlayers;
@@ -175,29 +192,33 @@ export default class RoundBids extends React.Component {
 
     const totalBids = players.map(p => gameState[p.playerName].bids[roundNumber-1] || 0).reduce((a,b)=>(+a || 0)+(+b || 0), 0);
     const roundBalance = totalBids - roundNumber; 
-    
+
     const canFinalize = currentBidder < 0 && roundBalance != 0;
-    const pendingBids = this.props.players.map((player) => (
+    const pendingBids = this.state.players.map((player) => (
       <div key={player.playerNumber}>
         <hr />
         <PendingBid
+          roundNumber={roundNumber}
           playerName={player.playerName}
           currentScore={this.state.gameState[player.playerName].scores[roundNumber-2]}
           currentBid={this.state.gameState[player.playerName].bids[roundNumber-1]}
           updateBid={this.updateBid.bind(this)}
-          maxBid={10}
+          maxBid={100}
           isPerfect={player.isPerfect}
           isDealer={dealerNumber === player.playerNumber} 
           isCurrentBidder = {currentBidder === player.playerNumber}/>
       </div>
     ));
     const errorMessage = "";
-
     return (
       <div>
         {roundBalance < 0 && <div className='roundBalance roundBalance-under'>{-roundBalance} under</div>}
         {roundBalance > 0 && <div className='roundBalance roundBalance-over'>{roundBalance} over</div>} 
-        <h2> Round: {this.state.roundNumber}/{totalNumRounds} </h2>
+        <div>
+          <button className="change-round" onClick={this.decrementRound.bind(this)}> &lt; </button>
+          <div className="bids-round-number"> Round: {this.state.roundNumber}/{totalNumRounds} </div>
+          <button className="change-round" onClick={this.incrementRound.bind(this)}> &gt; </button>
+        </div>
         <div className="vertDivider"/>
         {pendingBids}
         <hr />
@@ -213,28 +234,24 @@ export default class RoundBids extends React.Component {
 class PendingBid extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      playerName: this.props.playerName,
-      currentBid: this.props.currentBid,
-      currentScore: (this.props.currentScore) ? this.props.currentScore : 0,
-      maxBid: this.props.maxBid
-    }
   }
 
   increaseBid(event) {
-    if(this.state.currentBid === "-")
-      this.state.currentBid = 1;
-    else if (this.state.currentBid < this.props.maxBid)
-      this.setState( {currentBid: this.state.currentBid += 1 });
-    this.props.updateBid(this.props.playerName, this.state.currentBid)
+    var newBid = 0;    
+    if(this.props.currentBid === "-")
+      newBid = 1;
+    else if (this.props.currentBid < this.props.maxBid)
+      newBid =  this.props.currentBid + 1;
+    this.props.updateBid(this.props.playerName, newBid);
   }
 
   decreaseBid(event) {
-    if(this.state.currentBid === "-")
-      this.state.currentBid = 0;    
-    else if (this.state.currentBid > 0)
-      this.setState( {currentBid: this.state.currentBid -= 1 });
-    this.props.updateBid(this.props.playerName, this.state.currentBid)
+    var newBid = 0;
+    if(this.props.currentBid === "-")
+      newBid = 0;    
+    else if (this.props.currentBid > 0)
+      newBid = this.props.currentBid - 1;
+    this.props.updateBid(this.props.playerName, newBid);
   }
 
   render() {
@@ -244,11 +261,11 @@ class PendingBid extends React.Component {
 
     return (
       <div className={`player-row-bid ${this.props.isDealer && 'pending-bid-dealer'}`}>
-        <h3 className="player-name"> {this.state.playerName}: {this.state.currentScore} {perfectMark} </h3>
+        <h3 className="player-name"> {this.props.playerName}: {this.props.currentScore || 0} {perfectMark} </h3>
         
         <div className={`bid${this.props.isCurrentBidder ? " current-bidder" : ""}`}>
-          <button onClick={this.decreaseBid.bind(this)}>{this.state.currentBid === "-" ? "0" : "-"}</button>
-          <span className="current-bidtrick"> {this.state.currentBid} </span>
+          <button onClick={this.decreaseBid.bind(this)}>{this.props.currentBid === "-" ? "0" : "-"}</button>
+          <span className="current-bidtrick"> {this.props.currentBid} </span>
           <button onClick={this.increaseBid.bind(this)}>+</button>
         </div>
       </div>

--- a/src/scripts/roundBids.jsx
+++ b/src/scripts/roundBids.jsx
@@ -97,9 +97,12 @@ export default class RoundBids extends React.Component {
     //clear everything out
     this.setState({showAddPlayer: false, newPlayerName: null});
 
-    //increment player count and update firebase (for data consistency)
-    database.ref(`/players/${playerName}/count`).transaction(x => (x || 0) + 1);
-    this.updateFirebase();
+    if (!this.state.gameState.isDebug)
+    {
+      //increment player count and update firebase (for data consistency)
+      database.ref(`/players/${playerName}/count`).transaction(x => (x || 0) + 1);
+      this.updateFirebase();
+    }
   }
 
   updatePlayer(player) {

--- a/src/scripts/roundBids.jsx
+++ b/src/scripts/roundBids.jsx
@@ -9,7 +9,8 @@ export default class RoundBids extends React.Component {
   
   constructor(props) {
     super(props);
-    this.state= { players: this.props.players,
+    this.state= { roundNumber: this.props.roundNumber
+                  players: this.props.players,
                   gameState: this.props.gameState,
                   newPlayerGUID: getGUID(),
                   showAddPlayer: false};
@@ -27,7 +28,7 @@ export default class RoundBids extends React.Component {
   }
 
   updateBid(playerName, newBid) {
-    this.state.gameState[playerName].bids[this.state.gameState.roundNumber - 1] = parseInt(newBid);
+    this.state.gameState[playerName].bids[this.state.roundNumber - 1] = parseInt(newBid);
     this.forceUpdate();
   }
 
@@ -49,7 +50,7 @@ export default class RoundBids extends React.Component {
         minScore = player.currentScore
     }
 
-    const joinedRound = this.state.gameState.roundNumber;
+    const joinedRound = this.state.roundNumber;
 
     var newPlayer =
     {
@@ -72,7 +73,7 @@ export default class RoundBids extends React.Component {
       bids: Array(numRounds + 1).join('-').split(''),
       takes: Array(numRounds + 1).join('0').split('').map(parseFloat)
     };
-    newGameState["scores"][this.state.gameState.roundNumber - 2] = minScore;
+    newGameState["scores"][this.state.roundNumber - 2] = minScore;
     this.state.gameState[playerName] = newGameState;
     
     //clear everything out
@@ -157,13 +158,14 @@ export default class RoundBids extends React.Component {
     bid being updated, in that case.
   */
   render() {
+    const roundNumber = this.props.roundNumber;
     const gameState = this.props.gameState;
     const players = this.props.players;
     const numPlayers = players.length;
     const totalNumRounds = getNumberOfRounds(numPlayers);
-    const dealerNumber = (gameState.roundNumber -1) % numPlayers;
+    const dealerNumber = (roundNumber -1) % numPlayers;
     let currentBidder = (dealerNumber + 1) % numPlayers;
-    while(gameState[players[currentBidder].playerName].bids[gameState.roundNumber-1] !== "-") {
+    while(gameState[players[currentBidder].playerName].bids[roundNumber-1] !== "-") {
       currentBidder = (currentBidder + 1) % numPlayers;
       if(currentBidder == (dealerNumber + 1) % numPlayers) {
         currentBidder = -1;
@@ -171,8 +173,8 @@ export default class RoundBids extends React.Component {
       }
     }
 
-    const totalBids = players.map(p => gameState[p.playerName].bids[gameState.roundNumber-1] || 0).reduce((a,b)=>(+a || 0)+(+b || 0), 0);
-    const roundBalance = totalBids - gameState.roundNumber; 
+    const totalBids = players.map(p => gameState[p.playerName].bids[roundNumber-1] || 0).reduce((a,b)=>(+a || 0)+(+b || 0), 0);
+    const roundBalance = totalBids - roundNumber; 
     
     const canFinalize = currentBidder < 0 && roundBalance != 0;
     const pendingBids = this.props.players.map((player) => (
@@ -180,8 +182,8 @@ export default class RoundBids extends React.Component {
         <hr />
         <PendingBid
           playerName={player.playerName}
-          currentScore={this.state.gameState[player.playerName].scores[this.state.gameState.roundNumber-2]}
-          currentBid={this.state.gameState[player.playerName].bids[this.state.gameState.roundNumber-1]}
+          currentScore={this.state.gameState[player.playerName].scores[this.roundNumber-2]}
+          currentBid={this.state.gameState[player.playerName].bids[this.roundNumber-1]}
           updateBid={this.updateBid.bind(this)}
           maxBid={10}
           isPerfect={player.isPerfect}
@@ -195,7 +197,7 @@ export default class RoundBids extends React.Component {
       <div>
         {roundBalance < 0 && <div className='roundBalance roundBalance-under'>{-roundBalance} under</div>}
         {roundBalance > 0 && <div className='roundBalance roundBalance-over'>{roundBalance} over</div>} 
-        <h2> Round: {this.state.gameState.roundNumber}/{totalNumRounds} </h2>
+        <h2> Round: {this.state.roundNumber}/{totalNumRounds} </h2>
         <div className="vertDivider"/>
         {pendingBids}
         <hr />

--- a/src/scripts/statistics.jsx
+++ b/src/scripts/statistics.jsx
@@ -230,7 +230,7 @@ export default class Statistics extends React.Component {
     const { allGames, currentTab } = this.state;
 
     var games = currentTab === StatsTab.GAMES && this.state.allGames.map((gameWithKey) =>
-      <GameSummary key={gameWithKey.key} gameWithKey={gameWithKey} resume={null} showDelete={false} />
+      <GameSummary key={gameWithKey.key} gameWithKey={gameWithKey} resume={true} showDelete={true} />
     );
     var players = currentTab === StatsTab.PLAYERS && <GamePlayers allGames={allGames} />;
 

--- a/src/scripts/utils.jsx
+++ b/src/scripts/utils.jsx
@@ -134,6 +134,8 @@ export class GameSummary extends React.Component {
 
   deleteGame() {
     //delete the user-games for each player first, then the game
+    if(!confirm("Are you sure you want to delete this game?"))
+      return;
     var gameKey = this.props.gameWithKey.key;
     var updates = {};
     for (var player of this.props.gameWithKey.players)
@@ -165,7 +167,7 @@ export class GameSummary extends React.Component {
     var game = this.props.gameWithKey;
 
     var resumeButton = "";
-    if (this.props.resume && game.state.inProgress)
+    if (this.props.resume)
       resumeButton = (<button className="resume-game" onClick={this.resumeGame.bind(this)}> Resume </button>);
 
     var deleteButton = "";


### PR DESCRIPTION
Along with some small tweaks (showing delete buttons again, etc.)

The only thing to really keep in mind is that things only change in Firebase if the "Finalize Bids" or "End Round" buttons are pressed. So you can freely change the view between pages using the buttons around the Round heading. If you start changing things, they should work if you go in sequence, scores and perfection are updated correctly. If you jump between/over rounds, I'm not positive what will happen. A lot seems to hinge on the behavior of the calculateRoundScores function.